### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/dummy-for-automerge-minor-renovate-update.yaml
+++ b/.github/workflows/dummy-for-automerge-minor-renovate-update.yaml
@@ -1,0 +1,16 @@
+name: dummy check for merging automatically PR updating minor or patch update
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "*/package.json"
+      - "*/package-lock.json"
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: dummy
+        run: echo "dummy"

--- a/.github/workflows/publish_on_release.yaml
+++ b/.github/workflows/publish_on_release.yaml
@@ -1,0 +1,22 @@
+name: publish client
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-client-for-typescript:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: publish to npm
+        run: npm version ${GITHUB_REF##*/} && npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?
Add CI for automerging renovate's PR updating minor or patch update
Add CI for publishing package to npm on github release

## Why?
便利だから